### PR TITLE
Much Faster Primality Testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ bit-vec = "0.6.3"
 bincode = "1.3.3"
 serde   = { version = "1.0.130", features = ["derive"] }
 chrono  = "0.4"
+mod_exp = "1.0.1"

--- a/src/math/rapidmath.rs
+++ b/src/math/rapidmath.rs
@@ -219,6 +219,15 @@ impl Primality for u16 {
         }
     
         let witnesses = [2, 3];
+
+        for p in witnesses.iter() {
+            if *self == *p {
+                return true;
+            }
+            if *self % *p == 0 {
+                return false;
+            }
+        }
         
         'outer: for w in witnesses.iter() {
             let mut x = mod_exp(*w as u32,d as u32,*self as u32) as u16;
@@ -255,6 +264,15 @@ impl Primality for u32 {
     
         // Witnesses found by Jim Sinclair to cover all 32 bit integers
         let witnesses = [2, 7, 61];
+
+        for p in witnesses.iter() {
+            if *self == *p {
+                return true;
+            }
+            if *self % *p == 0 {
+                return false;
+            }
+        }
         
         'outer: for w in witnesses.iter() {
             let mut x = mod_exp(*w as u64,d as u64,*self as u64) as u32;
@@ -292,6 +310,15 @@ impl Primality for i32 {
     
         // Witnesses found by Jim Sinclair to cover all 32 bit integers
         let witnesses = [2, 7, 61];
+
+        for p in witnesses.iter() {
+            if *self == *p {
+                return true;
+            }
+            if *self % *p == 0 {
+                return false;
+            }
+        }
         
         'outer: for w in witnesses.iter() {
             let mut x = mod_exp(*w as i64,d as i64,*self as i64) as i32;

--- a/src/math/rapidmath.rs
+++ b/src/math/rapidmath.rs
@@ -1,6 +1,7 @@
 //! Traits and functions for general purpose, everyday mathematics.
 //! Temperature conversion, angle conversion etc. Everything you need.
 use super::constants;
+use mod_exp::mod_exp;
 
 /// The conversion algorithm to be chosen. Used by `temp_conversion`.
 pub enum TempConversion {
@@ -191,31 +192,48 @@ impl AngleConversionTrait for f32 {
     }
 }
 
+
+
 impl Primality for u8 {
     fn is_prime(&self) -> bool {
-        if self < &2 { return false; }
-        let mut i = 2;
-
-        while i.square() < *self {
-            match self % i {
-                0 => { return false; }
-                _ => { i += 1; }
-            }
-        }
-        true
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 
+        53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 
+        109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 
+        173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 
+        233, 239, 241, 251].contains(self)
     }
 }
 
 impl Primality for u16 {
     fn is_prime(&self) -> bool {
-        if self < &2 { return false; }
-        let mut i = 2;
 
-        while i.square() <= *self {
-            match self % i {
-                0 => { return false; }
-                _ => { i += 1; }
+        if *self <= 1 {
+            return false;
+        }
+    
+        let mut d = (*self-1)/2;
+        let mut r = 1;
+        while d % 2 == 0 {
+            d /= 2;
+            r += 1;
+        }
+    
+        let witnesses = [2, 3];
+        
+        'outer: for w in witnesses.iter() {
+            let mut x = mod_exp(*w as u32,d as u32,*self as u32) as u16;
+            
+            if x == 1 || x == *self-1 {
+                continue 'outer;
             }
+            for _ in 0..r-1 {
+                x = mod_exp(x as u32, 2u32, *self as u32) as u16;
+                
+                if x == *self-1 {
+                     continue 'outer;
+                }
+            }
+            return false;
         }
         true
     }
@@ -223,14 +241,35 @@ impl Primality for u16 {
 
 impl Primality for u32 {
     fn is_prime(&self) -> bool {
-        if self < &2 { return false; }
-        let mut i = 2;
 
-        while i.square() <= *self {
-            match self % i {
-                0 => { return false; }
-                _ => { i += 1; }
+        if *self <= 1 {
+            return false;
+        }
+    
+        let mut d = (*self-1)/2;
+        let mut r = 1;
+        while d % 2 == 0 {
+            d /= 2;
+            r += 1;
+        }
+    
+        // Witnesses found by Jim Sinclair to cover all 32 bit integers
+        let witnesses = [2, 7, 61];
+        
+        'outer: for w in witnesses.iter() {
+            let mut x = mod_exp(*w as u64,d as u64,*self as u64) as u32;
+            
+            if x == 1 || x == *self-1 {
+                continue 'outer;
             }
+            for _ in 0..r-1 {
+                x = mod_exp(x as u64, 2u64, *self as u64) as u32;
+                
+                if x == *self-1 {
+                     continue 'outer;
+                }
+            }
+            return false;
         }
         true
     }
@@ -238,14 +277,36 @@ impl Primality for u32 {
 
 impl Primality for i32 {
     fn is_prime(&self) -> bool {
-        if self < &2 { return false; }
-        let mut i = 2;
 
-        while i.square() <= *self {
-            match self % i {
-                0 => { return false; }
-                _ => { i += 1; }
+        // This also ensures that negative numbers are excluded as primes which is usually the case
+        if *self <= 1 {
+            return false;
+        }
+    
+        let mut d = (*self-1)/2;
+        let mut r = 1;
+        while d % 2 == 0 {
+            d /= 2;
+            r += 1;
+        }
+    
+        // Witnesses found by Jim Sinclair to cover all 32 bit integers
+        let witnesses = [2, 7, 61];
+        
+        'outer: for w in witnesses.iter() {
+            let mut x = mod_exp(*w as i64,d as i64,*self as i64) as i32;
+            
+            if x == 1 || x == *self-1 {
+                continue 'outer;
             }
+            for _ in 0..r-1 {
+                x = mod_exp(x as i64, 2i64, *self as i64) as i32;
+                
+                if x == *self-1 {
+                     continue 'outer;
+                }
+            }
+            return false;
         }
         true
     }
@@ -253,20 +314,56 @@ impl Primality for i32 {
 
 impl Primality for u64 {
     fn is_prime(&self) -> bool {
-        if self < &2 { return false; }
-        let mut i = 2;
 
-        while i.square() <= *self {
-            match self % i {
-                0 => { return false; }
-                _ => { i += 1; }
+        if *self <= 1 {
+            return false;
+        }
+    
+        // Witnesses found by Jim Sinclair to cover all 64 bit integers
+        let witnesses = [2, 325, 9375, 28178, 450775, 9780504, 1795265022];
+
+        // Instantly eliminate most compositive numbers by testing divisibility by primes less than 50
+        // Also test divisibility by each of the witnesses
+        let small_factors = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 325, 9375, 28178, 450775, 9780504, 1795265022];
+    
+        for p in small_factors.iter() {
+            if *self == *p {
+                return true;
             }
+            if *self % *p == 0 {
+                return false;
+            }
+        }
+        
+        let mut d = (*self-1)/2;
+        let mut r = 1;
+        while d % 2 == 0 {
+            d /= 2;
+            r += 1;
+        }
+    
+        'outer: for w in witnesses.iter() {
+            let mut x = mod_exp(*w as u128,d as u128,*self as u128) as u64;
+            
+            if x == 1 || x == *self-1 {
+                continue 'outer;
+            }
+            for _ in 0..r-1 {
+                x = mod_exp(x as u128, 2u128, *self as u128) as u64;
+                
+                if x == *self-1 {
+                     continue 'outer;
+                }
+            }
+            return false;
         }
         true
     }
 }
 
 impl Primality for u128 {
+    // Miller-Rabin could be used here as well but I don't know of deterministic witnesses for 128 bits.
+    // Perhaps a different trait could be given with the option for "probably prime"
     fn is_prime(&self) -> bool {
         if self < &2 { return false; }
         let mut i = 2;


### PR DESCRIPTION
There are deterministic Miller-Rabin values for u16, u32, and u64. I think the quickest method for u8 is just to lookup the primes. Primality testing for u128 is harder, I don't know of any quick deterministic test.